### PR TITLE
Add ScaleIn component

### DIFF
--- a/app/docs/animation/[...componentName]/page.tsx
+++ b/app/docs/animation/[...componentName]/page.tsx
@@ -157,7 +157,7 @@ const AnimationDocumentation = () => {
       </Tabs>
       {componentConfig.credits && (
         <>
-          <h2 className="text-2xl font-semibold">Credits</h2>
+          <h2 className="text-2xl font-semibold mt-10 mb-4">Credits</h2>
           <p
             dangerouslySetInnerHTML={{
               __html: sanitizeHtml(componentConfig.credits),

--- a/components/demo/scale-in.tsx
+++ b/components/demo/scale-in.tsx
@@ -1,0 +1,63 @@
+"use client";
+import React, { useEffect } from "react";
+import { motion, useAnimation, Variants } from "framer-motion";
+import { useInView } from "react-intersection-observer";
+
+interface ScaleInProps {
+  children: React.ReactNode;
+  duration?: number;
+  delay?: number;
+  scaleFrom?: number;
+  className?: string;
+  once?: boolean;
+}
+
+const ScaleIn: React.FC<ScaleInProps> = ({
+  children,
+  duration = 0.5,
+  delay = 0,
+  scaleFrom = 0.8,
+  className = "",
+  once = true,
+}) => {
+  const controls = useAnimation();
+  const [ref, inView] = useInView({
+    triggerOnce: once,
+    threshold: 0.1,
+  });
+
+  useEffect(() => {
+    if (inView) {
+      controls.start("visible");
+    } else if (!once) {
+      controls.start("hidden");
+    }
+  }, [controls, inView, once]);
+
+  const variants: Variants = {
+    hidden: { scale: scaleFrom, opacity: 0 },
+    visible: {
+      scale: 1,
+      opacity: 1,
+      transition: {
+        duration: duration,
+        delay: delay,
+        ease: [0.215, 0.61, 0.355, 1],
+      },
+    },
+  };
+
+  return (
+    <motion.div
+      ref={ref}
+      initial="hidden"
+      animate={controls}
+      variants={variants}
+      className={className}
+    >
+      {children}
+    </motion.div>
+  );
+};
+
+export default ScaleIn;

--- a/config/side-nav.ts
+++ b/config/side-nav.ts
@@ -24,6 +24,7 @@ export const sideNav: {
     subItems: [
       { title: "Text Writer", path: "/docs/animation/text-writer" },
       { title: "Smooth Reveal", path: "/docs/animation/smooth-reveal" },
+      { title: "Scale In", path: "/docs/animation/scale-in" },
     ],
   },
 ];

--- a/config/side-nav.ts
+++ b/config/side-nav.ts
@@ -22,9 +22,9 @@ export const sideNav: {
   {
     title: "Animation",
     subItems: [
-      { title: "Text Writer", path: "/docs/animation/text-writer" },
-      { title: "Smooth Reveal", path: "/docs/animation/smooth-reveal" },
       { title: "Scale In", path: "/docs/animation/scale-in" },
+      { title: "Smooth Reveal", path: "/docs/animation/smooth-reveal" },
+      { title: "Text Writer", path: "/docs/animation/text-writer" },
     ],
   },
 ];

--- a/content/docs/animation/scale-in.content.ts
+++ b/content/docs/animation/scale-in.content.ts
@@ -1,0 +1,71 @@
+import { ComponentConfigType } from "@/types/component-config.type";
+import { getAnimationPreview } from "@/lib/animation-preview";
+
+const ScaleInContent: ComponentConfigType = {
+  breadcrumbs: [
+    {
+      label: "Home",
+      href: "/",
+    },
+    {
+      label: "Docs",
+      href: "/docs",
+    },
+    {
+      label: "Animation",
+    },
+  ],
+  title: "Scale In",
+  description:
+    "The ScaleIn component creates a smooth scale-in animation for its children when they enter the viewport.",
+  usageCode: `${getAnimationPreview("scale-in", 1, true)}`,
+  installation: [
+    {
+      description: "Add the following code into your project",
+      isFullCode: true,
+    },
+    {
+      description: "Update the import paths according to your project setup",
+    },
+  ],
+  props: [
+    {
+      prop: "children",
+      type: "React.ReactNode",
+      defaultValue: "-",
+      description: "The content to be scaled in (required)",
+    },
+    {
+      prop: "duration",
+      type: "number",
+      defaultValue: "0.5",
+      description: "Duration of the animation (in seconds)",
+    },
+    {
+      prop: "delay",
+      type: "number",
+      defaultValue: "0",
+      description: "Delay before the animation starts (in seconds)",
+    },
+    {
+      prop: "scaleFrom",
+      type: "number",
+      defaultValue: "0.8",
+      description: "Initial scale value (between 0 and 1)",
+    },
+    {
+      prop: "className",
+      type: "string",
+      defaultValue: "''",
+      description: "Additional CSS classes for styling",
+    },
+    {
+      prop: "once",
+      type: "boolean",
+      defaultValue: "true",
+      description: "Whether to trigger the animation only once",
+    },
+  ],
+};
+
+export default ScaleInContent;

--- a/content/docs/animation/scale-in.content.ts
+++ b/content/docs/animation/scale-in.content.ts
@@ -66,6 +66,8 @@ const ScaleInContent: ComponentConfigType = {
       description: "Whether to trigger the animation only once",
     },
   ],
+  credits:
+    "Credits to <a target='_blank' style='font-weight: bold' href='https://github.com/lappemic' rel='noreferrer noopener'>Michael</a> for this awesome component.",
 };
 
 export default ScaleInContent;

--- a/content/docs/index.ts
+++ b/content/docs/index.ts
@@ -1,11 +1,13 @@
 import SmoothRevealConfig from "@/content/docs/animation/smooth-reveal.content";
 import TextWriterConfig from "@/content/docs/animation/text-writer.content";
+import ScaleInConfig from "@/content/docs/animation/scale-in.content";
 import { DocsConfigType } from "@/types/docs-config.type";
 
 const DocsContentConfig: DocsConfigType = {
   animation: {
     "text-writer": TextWriterConfig,
     "smooth-reveal": SmoothRevealConfig,
+    "scale-in": ScaleInConfig,
   },
 };
 

--- a/lib/animation-preview.tsx
+++ b/lib/animation-preview.tsx
@@ -1,6 +1,7 @@
 import SmoothReveal from "@/components/demo/smooth-reveal";
 import React from "react";
 import TextWriter from "@/components/demo/text-writer";
+import ScaleIn from "@/components/demo/scale-in";
 
 export const getAnimationPreview = (
   componentName: string,
@@ -32,6 +33,17 @@ export const getAnimationPreview = (
           className="text-4xl font-bold mb-4"
           delay={0.1}
         />
+      );
+    case "scale-in":
+      if (isString) {
+        return `<ScaleIn><div className="text-4xl font-bold mb-4">This content will scale in when visible</div></ScaleIn>`;
+      }
+      return (
+        <ScaleIn key={key}>
+          <div className="text-4xl font-bold mb-4">
+            This content will scale in when visible
+          </div>
+        </ScaleIn>
       );
     default:
       return "";

--- a/lib/animation-preview.tsx
+++ b/lib/animation-preview.tsx
@@ -11,18 +11,20 @@ export const getAnimationPreview = (
   switch (componentName) {
     case "smooth-reveal":
       if (isString) {
-        return `<SmoothReveal><p className="text-xl">This content will smoothly reveal on scroll</p></SmoothReveal>`;
+        return `<SmoothReveal><p className="text-2xl font-bold mb-4">This content will smoothly reveal on scroll</p></SmoothReveal>`;
       }
       return (
         <SmoothReveal key={key}>
-          <p className="text-xl">This content will smoothly reveal on scroll</p>
+          <p className="text-2xl font-bold mb-4">
+            This content will smoothly reveal on scroll
+          </p>
         </SmoothReveal>
       );
     case "text-writer":
       if (isString) {
         return `<TextWriter
   text="Welcome to ui/beats"
-  className="text-4xl font-bold mb-4"
+  className="text-2xl font-bold mb-4"
   delay={0.1}
 />`;
       }
@@ -30,17 +32,17 @@ export const getAnimationPreview = (
         <TextWriter
           key={key}
           text="Welcome to ui/beats"
-          className="text-4xl font-bold mb-4"
+          className="text-2xl font-bold mb-4"
           delay={0.1}
         />
       );
     case "scale-in":
       if (isString) {
-        return `<ScaleIn><div className="text-4xl font-bold mb-4">This content will scale in when visible</div></ScaleIn>`;
+        return `<ScaleIn><div className="text-2xl font-bold mb-4">This content will scale in when visible</div></ScaleIn>`;
       }
       return (
         <ScaleIn key={key}>
-          <div className="text-4xl font-bold mb-4">
+          <div className="text-2xl font-bold mb-4">
             This content will scale in when visible
           </div>
         </ScaleIn>


### PR DESCRIPTION
I've added a new ScaleIn component to ui-beats. This component makes content smoothly scale in when it appears on the screen. It's easy to use and customize, just like the `SmoothRevealContent` and the `TextWriter` components.

What's new:
* Created scale-in.tsx with the ScaleIn component
* Updated animation-preview.tsx to show ScaleIn examples
* Added documentation for ScaleIn in scale-in.content.ts
* Updated side navigation to include ScaleIn
* Updated docs content configuration to include ScaleIn

Take a look and let me know if you have any questions or suggestions!