### PR TITLE
fix: add delay for the fade in unblur effect to show

### DIFF
--- a/components/usage/animation/bounce.usage.tsx
+++ b/components/usage/animation/bounce.usage.tsx
@@ -3,7 +3,7 @@ import Bounce from "@/components/demo/animation/bounce";
 
 const BounceUsage = () => {
   return (
-    <Bounce>
+    <Bounce delay={1.2}>
       <div className="text-md md:text-lg mb-4">
         This content will bounce when visible
       </div>

--- a/components/usage/animation/fade-in.usage.tsx
+++ b/components/usage/animation/fade-in.usage.tsx
@@ -3,7 +3,7 @@ import FadeIn from "@/components/demo/animation/fade-in";
 
 const FadeInUsage = () => {
   return (
-    <FadeIn>
+    <FadeIn delay={1.2}>
       <p className="text-md md:text-lg mb-4">
         This content will fade in when it enters the viewport
       </p>

--- a/components/usage/animation/rotate-in.usage.tsx
+++ b/components/usage/animation/rotate-in.usage.tsx
@@ -3,7 +3,7 @@ import RotateIn from "@/components/demo/animation/rotate-in";
 
 const RotateInUsage = () => {
   return (
-    <RotateIn>
+    <RotateIn delay={1.2}>
       <div className="text-md md:text-lg mb-4">
         This content will rotate in when visible
       </div>

--- a/components/usage/animation/scale-in.usage.tsx
+++ b/components/usage/animation/scale-in.usage.tsx
@@ -3,7 +3,7 @@ import ScaleIn from "@/components/demo/animation/scale-in";
 
 const ScaleInUsage = () => {
   return (
-    <ScaleIn>
+    <ScaleIn delay={1.2}>
       <div className="text-md md:text-lg mb-4">
         This content will scale in when visible
       </div>

--- a/components/usage/animation/smooth-reveal.usage.tsx
+++ b/components/usage/animation/smooth-reveal.usage.tsx
@@ -3,7 +3,7 @@ import SmoothReveal from "@/components/demo/animation/smooth-reveal";
 
 const SmoothRevealUsage = () => {
   return (
-    <SmoothReveal>
+    <SmoothReveal delay={1.2}>
       <p className="text-md md:text-lg mb-4">
         This content will smoothly reveal on scroll
       </p>


### PR DESCRIPTION
## Issue:

When the page for animation loads, the animation for other components of the page makes it look like the previewed animation doesn't exist. 

https://github.com/user-attachments/assets/cbf7b753-ecd5-444e-84ab-43f748bcba20


## Fix:

Introduced a delay of approriate amount( 1.2second for now) so that the animation starts when the apperance animation completes. This is added to the previewed component only and will not show up when users will be copy pasting the code